### PR TITLE
Properly close script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
   <script src="bootstrap/bootstrap.min.js"></script>
   <script src="bootstrap/usebootstrap.js"></script>
-  <script src="scripts/handlebars-v3.0.3.js" />
+  <script src="scripts/handlebars-v3.0.3.js"></script>
 
 </head>
 <body>
@@ -71,7 +71,7 @@
     <p class="lead">It was a tough competition with many strong competitors, but in the end, it was the alliance of Albany and Head-Royce that ended up earning the title of 2015 Robotics Competition Champion. PiE would like to thank all of the teams for participating in the 2015 Season!</p>
   </div>
 </script>
-<script src="scripts/index.js" />
+<script src="scripts/index.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
@HannahLing0 @cwang395 Unfortunately script tags can't take a self-closing trailing slash.
